### PR TITLE
MsgProc_CellInfoNotify 读取RectInfo字段为空

### DIFF
--- a/Seamless/server/src/CellApp/space.go
+++ b/Seamless/server/src/CellApp/space.go
@@ -88,7 +88,7 @@ func (sp *Space) delCell(cellid uint64) {
 	sp.cells.Delete(cellid)
 
 	//把cellinfo广播给所有cellapp
-	sp.syncCellinfoToSpace(sp.cellSrv.GetCellMgrID(), cellid, nil, GetSrvInst().GetSrvID(), 3)
+	sp.syncCellinfoToSpace(sp.cellSrv.GetCellMgrID(), cellid, &protoMsg.RectInfo{}, GetSrvInst().GetSrvID(), 3)
 
 }
 


### PR DESCRIPTION
syncCellinfoToSpace 第3个RectInfo参数为空, 导致MsgProc_CellInfoNotify收到消息取RectInfo字段出错